### PR TITLE
Hook up main docs page in top bar and docs/index

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,3 +14,6 @@ layoutdir = "layouts"
   post = "/:year/:month/:title/"
   site = "/:filename/"
 #  docs = "/:section/"
+
+#[taxonomies]
+#  version = "versions"

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -1,0 +1,11 @@
+# InfluxDB Documentation
+
+Welcome to the InfluxDB documentation. Pick a version of the docs to get started, or navigate using the menu on the left for the documentation on the most recent version.
+
+## Current Version
+
+- [v0.9](v0.9/introduction/getting_started/)
+
+## Deprecated Versions
+
+- [v0.8](v0.8/introduction/getting_started/)

--- a/content/docs/v0.9/index.md
+++ b/content/docs/v0.9/index.md
@@ -1,1 +1,9 @@
-# Arf arf!
++++
+title = "v0.9.0 Documentation"
++++
+
+# InfluxDB Version 0.9 Documentation
+
+Welcome to the v0.9 documentation for InfluxDB.
+
+If this is your first time looking at InfluxDB, we recommend taking a look at the [getting started guide](introduction/getting_started/). Otherwise, documentation pages are listed in the sidebar.

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -2,7 +2,7 @@
 	<ol>
 		<li><a href="/support/index.html">Support</a></li>
 		<li><a href="http://customers.influxdb.com">Hosting</a></li>
-		<li><a href="/docs/index.html">Docs</a></li>
+		<li><a href="/docs/v0.9/introduction/getting_started/">Docs</a></li>
 		<li><a href="/blog/index.html">Blog</a></li>
 		<li><a href="/community/index.html">Community</a></li>
 		<li><a href="/about/index.html">About</a></li>

--- a/layouts/section/docs.html
+++ b/layouts/section/docs.html
@@ -3,6 +3,7 @@
 <div class="page-content">
 	<article class="article-docs article-main-column">
 		<h1 class="docs header">InfluxDB Documentation</h1>
+		Welcome to the InfluxDB documentation. Pick a version of the docs to get started, or navigate using the menu on the left for the documentation on the most recent version.
 		<ul class="blog-archive">
 		{{ range .Data.Pages }}
 			<h2 class="blog-heading"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>


### PR DESCRIPTION
- [x] Nav bar should link to getting started page.
- [ ] Docs sidebar should point to v0.9 docs.
- [ ] Add most recent influxdb.org updates.
- [ ] Update docs sidebar to remove non-existing v0.9 pages.

Non-critical issues:
- [ ] Make sure all existing links and pictures display correctly (especially for old docs).