### PR TITLE
Change key for measurement in input payload

### DIFF
--- a/content/docs/v0.9/concepts/reading_and_writing_data.md
+++ b/content/docs/v0.9/concepts/reading_and_writing_data.md
@@ -76,7 +76,7 @@ Which returns:
         {
             "series": [
                 {
-                    "name": "cpu_load_short",
+                    "measurement": "cpu_load_short",
                     "tags": {
                         "host": "server01",
                         "region": "us-west"
@@ -128,7 +128,7 @@ curl -XGET 'http://localhost:8086/query' --data-urlencode "db=mydb" --data-urlen
 ```
 
 ## Authentication
-Authentication is disabled by default. If authentication is enabled, user credentials must be supplied with every query. These can be suppled via the URL parameters `u` and `p`. For example, if the user is "bob" and the password is "mypass", then endpoint URL should take the form `/query?u=bob&p=mypass`.
+Authentication is disabled by default. If authentication is enabled, user credentials must be supplied with every query. These can be supplied via the URL parameters `u` and `p`. For example, if the  user is "bob" and the password is "mypass", then endpoint URL should take the form `/query?u=bob&p=mypass`.
 
 The credentials may also be passed using _Basic Authentication_. If both types of authentication are present in a request, the URL parameters take precedence.
 


### PR DESCRIPTION
It seems key name in input payload to add points is changed to 'measurement' from 'name'.