### PR TITLE
Fix install instructions

### DIFF
--- a/content/docs/v0.9/introduction/installation.md
+++ b/content/docs/v0.9/introduction/installation.md
@@ -14,7 +14,7 @@ Debian users can install 0.9.0 by downloading the package and installing it like
 ```bash
 # 64-bit system install instructions
 wget http://influxdb.s3.amazonaws.com/influxdb_0.9.0_amd64.deb
-sudo dpkg -i influxdb_latest_amd64.deb
+sudo dpkg -i influxdb_0.9.0_amd64.deb
 ```
 
 Then start the daemon by running:
@@ -29,7 +29,7 @@ RedHat and CentOS users can install by downloading and installing the rpm like t
 ```bash
 # 64-bit system install instructions
 wget http://influxdb.s3.amazonaws.com/influxdb-0.9.0-1.x86_64.rpm
-sudo rpm -ivh influxdb-latest-1.x86_64.rpm
+sudo rpm -ivh influxdb-0.9.0-1.x86_64.rpm
 ```
 
 Then start the daemon by running:


### PR DESCRIPTION
D/l'd file didn't match name in next statement of instructions