### PR TITLE
Read/write example: POST payload must not start with new line.

### DIFF
--- a/content/docs/v0.9/concepts/reading_and_writing_data.md
+++ b/content/docs/v0.9/concepts/reading_and_writing_data.md
@@ -24,8 +24,7 @@ InfluxDB is schemaless so the series and columns (fields and tags) get created o
 As you can see in the example below, you can post multiple points to multiple series at the same time by separating each point with a new line. Batching points in this manner will result in much higher performance.
 
 ```
-curl -i -XPOST 'http://localhost:8086/write?db=mydb' -d '
-cpu_load_short,host=server01,region=us-west value=0.64
+curl -i -XPOST 'http://localhost:8086/write?db=mydb' -d 'cpu_load_short,host=server01,region=us-west value=0.64
 cpu_load_short,host=server02,region=us-west value=0.55 1422568543702900257
 cpu_load_short,direction=in,host=server01,region=us-west value=23422.0 1422568543702900257'
 ```


### PR DESCRIPTION
In the documentation, in the basic read/write example of writing multiple records at once, if the payload starts with new line, it does not work.