### PR TITLE
fix typo ("tags" should be "tag")

### DIFF
--- a/content/docs/v0.9/introduction/getting_started.md
+++ b/content/docs/v0.9/introduction/getting_started.md
@@ -82,7 +82,7 @@ To insert a single time-series datapoint into InfluxDB using the CLI, enter `INS
 >
 ```
 
-A point with the measurement name of `cpu` and tags `host` has now been written to the database, with the measured value of `0.64`.
+A point with the measurement name of `cpu` and tag `host` has now been written to the database, with the measured value of `0.64`.
 
 Now we will query for the data we just wrote.
 


### PR DESCRIPTION
Fixing a typo. "tags" should be singular in the following sentence:

"...with the measurement name of cpu and **tags** host has now been written..."

Found on https://influxdb.com/docs/v0.9/introduction/getting_started.html
