### PR TITLE
Fix bad link in CLI documentation

### DIFF
--- a/content/docs/v0.9/clients/shell.md
+++ b/content/docs/v0.9/clients/shell.md
@@ -118,7 +118,7 @@ Format          csv
 
 ### Issuing Queries
 
-For a complete reference to the query language, please read the [online documentation](http://influxdb.com/docs).
+For a complete reference to the query language, please read the [online documentation](/docs/v0.9/query_language/querying_data.html).
 
 #### show databases
 


### PR DESCRIPTION
Solved issue [56](https://github.com/influxdb/influxdb.com/issues/56).
Link now leads to `/docs/v0.9/query_language/querying_data.html` instead of `/docs`