### PR TITLE
Change first curl example to specify a database

### DIFF
--- a/content/docs/v0.9/query_language/querying_data.md
+++ b/content/docs/v0.9/query_language/querying_data.md
@@ -7,7 +7,7 @@ InfluxDB features an SQL-like query language for querying data and performing ag
 The primary mechanism for issuing any of the queries listed below is through the HTTP API. For example, the command `SELECT * FROM cpu` can be executed using `curl` as follows:
 
 ```
-curl -G 'http://localhost:8086/query' --data-urlencode "q=SELECT * FROM cpu"
+curl -G 'http://localhost:8086/query' --data-urlencode "db=mydb" --data-urlencode "q=SELECT * FROM cpu"
 ```
 ## Quote Usage
 *Identifiers* are either unquoted or double quoted. Identifiers are database names, retention policies, measurements, or tag keys. String literals are always single quoted however.


### PR DESCRIPTION
As noted in [53](https://github.com/influxdb/influxdb.com/issues/53),
the current query returns `{"results":[{"error":"database name
required"}]}`. To remedy this, I specify a database `mydb`.