### PR TITLE
show retention policies now requires "ON"

### DIFF
--- a/content/docs/v0.9/administration/administration.md
+++ b/content/docs/v0.9/administration/administration.md
@@ -151,13 +151,13 @@ Durations such as `1h`, `90m`, `12h`, `7d`, and `4w`, are all supported and mean
 To delete a retention policy issue the following command:
 
 ```sql
-SHOW RETENTION POLICIES <database>
+SHOW RETENTION POLICIES ON <database>
 ```
 
 _Example_
 
 ```sql
-SHOW RETENTION POLICIES mydb
+SHOW RETENTION POLICIES ON mydb
 ```
 
 The response returned is:

--- a/content/docs/v0.9/query_language/spec.md
+++ b/content/docs/v0.9/query_language/spec.md
@@ -478,14 +478,14 @@ SHOW MEASUREMENTS WHERE region = 'uswest' AND host = 'serverA'
 ### SHOW RETENTION POLICIES
 
 ```
-show_retention_policies = "SHOW RETENTION POLICIES" db_name .
+show_retention_policies = "SHOW RETENTION POLICIES ON" db_name .
 ```
 
 #### Example:
 
 ```sql
 -- show all retention policies on a database
-SHOW RETENTION POLICIES mydb
+SHOW RETENTION POLICIES ON mydb
 ```
 
 ### SHOW SERIES


### PR DESCRIPTION
Was playing with the latest nightly build, ran into an issue trying to show retention policies. Looks like syntax got updated recently. https://github.com/influxdb/influxdb/commit/ee8ba11c4fdb30f5ae5c7d1c468d7985bf2232fd

Looks like this syntax does NOT work with 0.9.1. Not sure what the style guideline would be here for denoting differences between minor versions. I'll gladly update this PR if there's an example of how to show 0.9.1 syntax vs 0.9.2.

Thanks!