### PR TITLE
fix: Specify "yum" not "rpm"

### DIFF
--- a/content/docs/v0.6/introduction/installation.md
+++ b/content/docs/v0.6/introduction/installation.md
@@ -30,11 +30,11 @@ RedHat and CentOS users can install by downloading and installing the rpm like t
 ```bash
 # for 64-bit systems
 wget https://s3.amazonaws.com/influxdb/influxdb-0.6.5-1.x86_64.rpm
-sudo rpm -ivh influxdb-latest-1.x86_64.rpm
+sudo yum localinstall influxdb-latest-1.x86_64.rpm
 
 # for 32-bit systems
 wget https://s3.amazonaws.com/influxdb/influxdb-0.6.5-1.i686.rpm
-sudo rpm -ivh influxdb-latest-1.i686.rpm
+sudo yum localinstall influxdb-latest-1.i686.rpm
 ```
 
 Then start the daemon by running:

--- a/content/docs/v0.7/introduction/installation.md
+++ b/content/docs/v0.7/introduction/installation.md
@@ -37,11 +37,11 @@ RedHat and CentOS users can install by downloading and installing the rpm like t
 ```bash
 # for 64-bit systems
 wget https://s3.amazonaws.com/influxdb/influxdb-0.7.3-1.x86_64.rpm
-sudo rpm -ivh influxdb-latest-1.x86_64.rpm
+sudo yum localinstall influxdb-latest-1.x86_64.rpm
 
 # for 32-bit systems
 wget https://s3.amazonaws.com/influxdb/influxdb-0.7.3-1.i686.rpm
-sudo rpm -ivh influxdb-latest-1.i686.rpm
+sudo yum localinstall influxdb-latest-1.i686.rpm
 ```
 
 Then start the daemon by running:

--- a/content/docs/v0.8/introduction/installation.md
+++ b/content/docs/v0.8/introduction/installation.md
@@ -56,11 +56,11 @@ RedHat and CentOS users can install by downloading and installing the rpm like t
 ```bash
 # for 64-bit systems
 wget https://s3.amazonaws.com/influxdb/influxdb-0.8.8-1.x86_64.rpm
-sudo rpm -ivh influxdb-0.8.8-1.x86_64.rpm
+sudo yum localinstall influxdb-0.8.8-1.x86_64.rpm
 
 # for 32-bit systems
 wget https://s3.amazonaws.com/influxdb/influxdb-0.8.8-1.i686.rpm
-sudo rpm -ivh influxdb-0.8.8-1.i686.rpm
+sudo yum localinstall influxdb-0.8.8-1.i686.rpm
 ```
 
 Then start the daemon by running:

--- a/content/docs/v0.9/introduction/installation.md
+++ b/content/docs/v0.9/introduction/installation.md
@@ -31,7 +31,7 @@ RedHat and CentOS users can install by downloading and installing the rpm like t
 ```bash
 # 64-bit system install instructions
 wget http://influxdb.s3.amazonaws.com/influxdb-0.9.2-1.x86_64.rpm
-sudo rpm -ivh influxdb-0.9.2-1.x86_64.rpm
+sudo yum localinstall influxdb-0.9.2-1.x86_64.rpm
 ```
 
 Then start the daemon by running:

--- a/content/site/chronograf-download.md
+++ b/content/site/chronograf-download.md
@@ -18,7 +18,7 @@ Installing Chronograf on either a Debian/Ubuntu or RedHat/CentOS distribution of
 - 64-bit system instructions
 
 		wget https://s3.amazonaws.com/get.influxdb.org/chronograf/chronograf-0.1.0-1.x86_64.rpm
-		sudo rpm -ivh chronograf-0.1.0-1.x86_64.rpm
+		sudo yum localinstall chronograf-0.1.0-1.x86_64.rpm
 
 # Usage
 

--- a/content/site/download.md
+++ b/content/site/download.md
@@ -25,7 +25,7 @@ layout = "sidebar"
 - 64-bit system install instructions
 
 		wget https://s3.amazonaws.com/influxdb/influxdb-0.9.2-1.x86_64.rpm
-		sudo rpm -ivh influxdb-0.9.2-1.x86_64.rpm
+		sudo yum localinstall influxdb-0.9.2-1.x86_64.rpm
 
 ## Version 0.9.3 (Nightly)
 Nightly builds are created once-a-day using the top-of-tree of [master](https://github.com/influxdb/influxdb/tree/master) source code. These builds will include all the latest fixes, but also undergo only basic testing.
@@ -42,7 +42,7 @@ Nightly builds are created once-a-day using the top-of-tree of [master](https://
 - 64-bit system install instructions
 
         wget https://s3.amazonaws.com/influxdb/influxdb-nightly-1.x86_64.rpm
-        sudo rpm -ivh influxdb-nightly-1.x86_64.rpm
+        sudo yum localinstall influxdb-nightly-1.x86_64.rpm
 
 
 ### Deprecated Releases
@@ -75,5 +75,5 @@ Deprecated versions are no longer actively developed.
 - 64-bit system install instructions
 
 		wget http://get.influxdb.org/telegraf/telegraf-0.1.4-1.x86_64.rpm
-		sudo rpm -ivh telegraf-0.1.4-.x86_64.rpm
+		sudo yum localinstall telegraf-0.1.4-.x86_64.rpm
 


### PR DESCRIPTION
When installing packages on RPM based systems the best practice
is to use the command "yum localinstall" not "rpm".  This mananges
any dependencies on behalf of the user.  While influxdb should be
self sufficient, it's best to rely on the package manager and not
it's primitives.