### PR TITLE
Correct two spelling mistakes in write_syntax.md

### DIFF
--- a/content/docs/v0.9/write_protocols/write_syntax.md
+++ b/content/docs/v0.9/write_protocols/write_syntax.md
@@ -35,7 +35,7 @@ backslash character `\`.
 Measurements, tag keys, tag values, and field keys are always stored as strings in the database. 
 
 `string` values have a length limit of 64 KB. All Unicode characters should be valid, although commas and spaces 
-require escaping. Backslash characters do not require escaping, but may not be used directly preceeding a comma or space. (Note that `string` field values have different quoting and escaping rules than the measurement, tag, and field name `string` syntax.)
+require escaping. Backslash characters do not require escaping, but may not be used directly preceding a comma or space. (Note that `string` field values have different quoting and escaping rules than the measurement, tag, and field name `string` syntax.)
 
 Field values may be stored as `float64`, `int64`, `boolean`, or `string`. All subsequent field values must match 
 the type of the first point written to given measurement. 
@@ -70,7 +70,7 @@ disk_free,hostname=server01,disk_type=SSD value=442221834240i
 disk_free,hostname=server01,disk_type=SSD value=442221834240i 1435362189575692182
 ```
 
-#### Multilple Fields
+#### Multiple Fields
 ```
 disk_free free_space=442221834240i,disk_type="SSD" 1435362189575692182
 ```


### PR DESCRIPTION
just a tiny correction.

I also spotted that the documentation lacks the fact (or I missed it at least) that lines starting with '#' are ignored.