### PR TITLE
Update download.md with correct links

### DIFF
--- a/content/site/download.md
+++ b/content/site/download.md
@@ -17,15 +17,15 @@ layout = "sidebar"
 
 - 64-bit system install instructions
 
-		wget https://s3.amazonaws.com/influxdb/influxdb_0.9.2_amd64.deb
-		sudo dpkg -i influxdb_0.9.2_amd64.deb
+		wget https://s3.amazonaws.com/influxdb/influxdb_0.9.2.1_amd64.deb
+		sudo dpkg -i influxdb_0.9.2.1_amd64.deb
 
 #### RedHat & CentOS
 
 - 64-bit system install instructions
 
-		wget https://s3.amazonaws.com/influxdb/influxdb-0.9.2-1.x86_64.rpm
-		sudo yum localinstall influxdb-0.9.2-1.x86_64.rpm
+		wget https://s3.amazonaws.com/influxdb/influxdb-0.9.2.1-1.x86_64.rpm
+		sudo yum localinstall influxdb-0.9.2.1-1.x86_64.rpm
 
 
 ## Version 0.9.3 (Release Candidate)


### PR DESCRIPTION
Apparently the latest stable is 0.9.2.1 rather than 0.9.2. It's a bit confusing for people how are visiting website without checking the github.

Is it a missed point or there is a reason to have a link to 0.9.2?