### PR TITLE
Add rust libary from support email

### DIFF
--- a/content/docs/v0.9/clients/api.md
+++ b/content/docs/v0.9/clients/api.md
@@ -38,3 +38,6 @@ This is a list of the client libraries which have some support for InfluxDB vers
 ## Ruby
 - [InfluxDB Ruby](https://github.com/influxdb/influxdb-ruby)
 - [Influxer](https://github.com/palkan/influxer) by [palkan](https://github.com/palkan)
+
+## Rust
+- [Influent.rs](https://github.com/gobwas/influent.rs) by [gobwas](https://github.com/gobwas)


### PR DESCRIPTION
From support email:

>Hi again, guys!

>Just wanted you to know, that I've developed also a Rust driver for the InfluxDB 0.9.3.

>https://github.com/gobwas/influent.rs

>Regards,

>Sergey Kamardin.