### PR TITLE
Use /etc/default/influxdb in cluster instructions

### DIFF
--- a/content/docs/v0.9/guides/clustering.md
+++ b/content/docs/v0.9/guides/clustering.md
@@ -27,9 +27,9 @@ Throughout this example, each node will be given a number that denotes the order
 2. For each node's `/etc/opt/influxdb/influxdb.conf` file, replace `hostname = "localhost"` with your host's actual name. This hostname must be resolved by all members in the cluster. It can be an IP or a hostname and optional port number if necessary.
 3. For each node's `/etc/opt/influxdb/influxdb.conf` file, update the bind-address to another port if `8088` is unacceptable. The bind-address can also specify the host interface IP to use (e.g. `10.0.1.10:8088`). By default it will bind on all interfaces. Note that the port may differ from node to node (e.g. one can use `8088`, another use `9099`, and the other `10101`).
 4. Start InfluxDB on the first node, `sudo service influxdb start` (or `sudo systemctl start influxdb` if you are using systemd).
-5. In `/etc/init.d/influxdb` on the second node, set `INFLUXD_OPTS="-join hostname_1:port_1"`.  If using systemd this command must be set in the `/etc/default/influxdb` file.  If it does not exist, create it.
+5. In `/etc/default/influxdb` on the second node, set `INFLUXD_OPTS="-join hostname_1:port_1"`. If the file does not exist, create it.
 6. Start InfluxDB on the second node, `sudo service influxdb start` (or `sudo systemctl start influxdb` if you are using systemd).
-7. In `/etc/init.d/influxdb` on the third node, set `INFLUXD_OPTS="-join hostname_1:port_1,hostname_2:port_2"`.  If using systemd this command must be set in the `/etc/default/influxdb` file.  If it does not exist, create it.
+7. In `/etc/default/influxdb` on the third node, set `INFLUXD_OPTS="-join hostname_1:port_1,hostname_2:port_2"`. If the file does not exist, create it.
 8. Start InfluxDB on the third node, `sudo service influxdb start` (or `sudo systemctl start influxdb` if you are using systemd).
 
 > **Note:** As an alternative to steps 3 and 4, an additional `-hostname host[:port]` flag may be provided to `INFLUXD_OPTS`.
@@ -63,7 +63,7 @@ Once you have verified that your raft cluster is healthy and running appropriate
 1. Install InfluxDB on the new node.
 2. In the new node's `/etc/opt/influxdb/influxdb.conf` file, replace `hostname = "localhost"` with the nodes hosts actual name. This hostname must be resolved by all members in the cluster. It can be an IP or a hostname and optional port number if necessary.
 3. In the new node's `/etc/opt/influxdb/influxdb.conf` file, update the bind-address to another port if `8088` is unacceptable. The bind-address can also specify the host interface IP to use (e.g. `10.0.1.10:8088`). By default it will bind on all interfaces. Note that the port may differ from node to node (e.g. one can use `8088`, another use `9099`, and the other `10101`).
-4. In the new node's `/etc/init.d/influxdb` file, set `INFLUXD_OPTS="-join hostname_1:port_1,hostname_2:port_2"`.  If using systemd this command must be set in the `/etc/default/influxdb` file.  If it does not exist, create it.
+4. In the new node's `/etc/default/influxdb` file, set `INFLUXD_OPTS="-join hostname_1:port_1,hostname_2:port_2"`. If the file does not exist, create it.
 5. Start InfluxDB on the new node, `sudo service influxdb start` (or `sudo systemctl start influxdb` if you are using systemd).
 
 > **Note:** When using the `-join` you need only specify one `hostname:port` pair. However, if more than one is provided, Influx will try to connect with the additional pairs in the case that it cannot connect with the first one.


### PR DESCRIPTION
Both sysvinit and systemd use /etc/default/influxdb so the instructions can
be simplified.