### PR TITLE
Corrects CREATE DATABASE IF NOT EXISTS grammar

### DIFF
--- a/content/docs/v0.9/query_language/database_management.md
+++ b/content/docs/v0.9/query_language/database_management.md
@@ -28,7 +28,7 @@ The examples in the sections below use InfluxDB's [Command Line Interface (CLI)]
 ---
 The `CREATE DATABASE` query takes the following form, where `IF NOT EXISTS` is optional:
 ```sql
-CREATE DATABASE <database_name> [IF NOT EXISTS]
+CREATE DATABASE [IF NOT EXISTS] <database_name>
 ```
 
 Create the database ` NOAA_water_database`:
@@ -39,7 +39,7 @@ Create the database ` NOAA_water_database`:
 
 Create the database `NOAA_water_database` only if it doesn't exist:
 ```sh
-> CREATE DATABASE  NOAA_water_database IF NOT EXISTS
+> CREATE DATABASE IF NOT EXISTS NOAA_water_database
 >
 ```
 


### PR DESCRIPTION
`IF NOT EXISTS` is before the database name rather than after.

I double checked master to make sure it hasn't changed in v0.9.5:
https://github.com/influxdb/influxdb/blob/a3d127f797fec3ae24d10dda5bedb498bcab87eb/influxql/parser_test.go#L1184

