### PR TITLE
Add sample data download page and link to it from relevant documents

### DIFF
--- a/content/docs/v0.9/query_language/data_exploration.md
+++ b/content/docs/v0.9/query_language/data_exploration.md
@@ -42,7 +42,7 @@ The examples below query data using [InfluxDB's Command Line Interface (CLI)](..
 <br>
 This document uses publicly available data from the [National Oceanic and Atmospheric Administration's (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html?type=Water+Levels). The data include water levels (ft) collected every six seconds at two stations (Santa Monica, CA (ID 9410840) and Coyote Creek, CA (ID 9414575)) over the period from August 18, 2015 through September 18, 2015.
 
-A subsample of the data in InfluxDB: 
+A subsample of the data in the measurement `h2o_feet`: 
 ```
 name: h2o_feet
 --------------
@@ -62,6 +62,8 @@ time			                 level description	      location	       water_level
 The [series](../concepts/glossary.html#series) are made up of the [measurement](../concepts/glossary.html#measurement) `h2o_feet` and the [tag key](../concepts/glossary.html#tag-key) `location` with the [tag values](../concepts/glossary.html#tag-value) `santa_monica` and `coyote_creek`. There are two [fields](../concepts/glossary.html#field): `water_level` which stores floats and `level description` which stores strings. All of the data are in the `NOAA_water_database` database.
 
 > **Disclaimer:** The `level description` field isn't part of the original NOAA data - we snuck it in there for the sake of having a field key with a special character and string [field values](../concepts/glossary.html#field-value).
+
+If you'd like to follow along with the queries in this document, see [Sample Data](../sample_data/data_download.html) for how to download and write the data to InfluxDB.
 
 ## The SELECT statement and the `WHERE` clause
 InfluxQL's `SELECT` statement follows the form of an SQL `SELECT` statement where the `WHERE` clause is optional:

--- a/content/docs/v0.9/query_language/data_exploration.md
+++ b/content/docs/v0.9/query_language/data_exploration.md
@@ -40,6 +40,8 @@ The examples below query data using [InfluxDB's Command Line Interface (CLI)](..
 
 #### Sample data
 <br>
+If you'd like to follow along with the queries in this document, see [Sample Data](../sample_data/data_download.html) for how to download and write the data to InfluxDB.
+
 This document uses publicly available data from the [National Oceanic and Atmospheric Administration's (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html?type=Water+Levels). The data include water levels (ft) collected every six seconds at two stations (Santa Monica, CA (ID 9410840) and Coyote Creek, CA (ID 9414575)) over the period from August 18, 2015 through September 18, 2015.
 
 A subsample of the data in the measurement `h2o_feet`: 
@@ -62,8 +64,6 @@ time			                 level description	      location	       water_level
 The [series](../concepts/glossary.html#series) are made up of the [measurement](../concepts/glossary.html#measurement) `h2o_feet` and the [tag key](../concepts/glossary.html#tag-key) `location` with the [tag values](../concepts/glossary.html#tag-value) `santa_monica` and `coyote_creek`. There are two [fields](../concepts/glossary.html#field): `water_level` which stores floats and `level description` which stores strings. All of the data are in the `NOAA_water_database` database.
 
 > **Disclaimer:** The `level description` field isn't part of the original NOAA data - we snuck it in there for the sake of having a field key with a special character and string [field values](../concepts/glossary.html#field-value).
-
-If you'd like to follow along with the queries in this document, see [Sample Data](../sample_data/data_download.html) for how to download and write the data to InfluxDB.
 
 ## The SELECT statement and the `WHERE` clause
 InfluxQL's `SELECT` statement follows the form of an SQL `SELECT` statement where the `WHERE` clause is optional:

--- a/content/docs/v0.9/query_language/functions.md
+++ b/content/docs/v0.9/query_language/functions.md
@@ -22,7 +22,7 @@ The examples below query data using [InfluxDB's Command Line Interface (CLI)](..
 
 **Sample data**
 
-The examples in this document use the same sample data as the [Data Exploration](../query_language/data_exploration.html) page.
+The examples in this document use the same sample data as the [Data Exploration](../query_language/data_exploration.html) page. If you'd like to follow along with the queries in this document, see [Sample Data](../sample_data/data_download.html) for how to download and write the data to InfluxDB.
 
 # Aggregations
 

--- a/content/docs/v0.9/query_language/functions.md
+++ b/content/docs/v0.9/query_language/functions.md
@@ -22,7 +22,7 @@ The examples below query data using [InfluxDB's Command Line Interface (CLI)](..
 
 **Sample data**
 
-The examples in this document use the same sample data as the [Data Exploration](../query_language/data_exploration.html) page. If you'd like to follow along with the queries in this document, see [Sample Data](../sample_data/data_download.html) for how to download and write the data to InfluxDB.
+The examples in this document use the same sample data as the [Data Exploration](../query_language/data_exploration.html) page. The data are described and are available for download on the [Sample Data](../sample_data/data_download.html) page.
 
 # Aggregations
 

--- a/content/docs/v0.9/query_language/schema_exploration.md
+++ b/content/docs/v0.9/query_language/schema_exploration.md
@@ -16,9 +16,7 @@ The examples below query data using [InfluxDB's Command Line Interface (CLI)](..
 
 **Sample data**
 
-This document uses the same sample data as the [Data Exploration](../query_language/data_exploration.html) page. Note that some of the measurements and data in the database are fictional - they're meant to make the next sections more explanatory and (hopefully) more interesting. The next sections will get you acquainted with the schema of the sample data in the `NOAA_water_database` database.
-
-If you’d like to follow along with the queries in this document, see [Sample Data](../sample_data/data_download.html) for how to download and write the data to InfluxDB.
+This document uses the same sample data as the [Data Exploration](../query_language/data_exploration.html) page. The data are described and are available for download on the [Sample Data](../sample_data/data_download.html) page.
 
 ## See all databases with `SHOW DATABASES`
 Get a list of all the databases in your system by entering:

--- a/content/docs/v0.9/query_language/schema_exploration.md
+++ b/content/docs/v0.9/query_language/schema_exploration.md
@@ -18,6 +18,8 @@ The examples below query data using [InfluxDB's Command Line Interface (CLI)](..
 
 This document uses the same sample data as the [Data Exploration](../query_language/data_exploration.html) page. Note that some of the measurements and data in the database are fictional - they're meant to make the next sections more explanatory and (hopefully) more interesting. The next sections will get you acquainted with the schema of the sample data in the `NOAA_water_database` database.
 
+If you’d like to follow along with the queries in this document, see [Sample Data](../sample_data/data_download.html) for how to download and write the data to InfluxDB.
+
 ## See all databases with `SHOW DATABASES`
 Get a list of all the databases in your system by entering:
 ```sql

--- a/content/docs/v0.9/sample_data/data_download.md
+++ b/content/docs/v0.9/sample_data/data_download.md
@@ -1,0 +1,79 @@
+---
+title: Sample data
+---
+
+Download and write to InfluxDB the sample data used in [Data Exploration](../query_language/data_exploration.html), [Schema Exploration](../query_language/schema_exploration.html), and [Functions](../query_language/functions.html).
+
+### Download and write the data to InfluxDB
+From your terminal, create the database `NOAA_water_database`:
+```
+curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE NOAA_water_database"
+```
+
+Download the text file that contains the data in [line protocol](https://influxdb.com/docs/v0.9/write_protocols/line.html) format:
+```
+curl https://s3-us-west-1.amazonaws.com/noaa.water.database.0.9/NOAA_data.txt > NOAA_data1.txt
+```
+
+Write the data to InfluxDB:
+```
+curl -i -XPOST "http://localhost:8086/write?db=NOAA_water_database&precision=s" --data-binary @NOAA_data1.txt
+```
+
+### Test queries
+See all five measurements:
+```sql
+> SHOW measurements
+```
+
+```sh
+name: measurements
+------------------
+name
+average_temperature
+h2o_feet
+h2o_pH
+h2o_quality
+h2o_temperature
+```
+
+Count the number of non-null values of `water_level` in `h2o_feet`:
+```sql
+> SELECT COUNT(water_level) FROM h2o_feet
+```
+
+```sh
+name: h2o_feet
+--------------
+time			               count
+1970-01-01T00:00:00Z	 15258
+```
+
+Select the first ten observations in the measurement h2o_feet:
+
+```sql
+> SELECT * FROM h2o_feet LIMIT 10
+```
+
+```sh
+name: h2o_feet
+--------------
+time			                 level description	      location	       water_level
+2015-08-18T00:00:00Z	   below 3 feet		          santa_monica	   2.064
+2015-08-18T00:00:00Z	   between 6 and 9 feet	   coyote_creek	   8.12
+2015-08-18T00:06:00Z	   between 6 and 9 feet	   coyote_creek	   8.005
+2015-08-18T00:06:00Z	   below 3 feet		          santa_monica	   2.116
+2015-08-18T00:12:00Z	   between 6 and 9 feet	   coyote_creek	   7.887
+2015-08-18T00:12:00Z	   below 3 feet		          santa_monica	   2.028
+2015-08-18T00:18:00Z	   between 6 and 9 feet	   coyote_creek	   7.762
+2015-08-18T00:18:00Z	   below 3 feet		          santa_monica	   2.126
+2015-08-18T00:24:00Z	   between 6 and 9 feet	   coyote_creek	   7.635
+2015-08-18T00:24:00Z	   below 3 feet		          santa_monica	   2.041
+```
+
+### Data sources and things to note
+We use publicly available data from the [National Oceanic and Atmospheric Administration’s (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html?type=Water+Levels). The data include water levels (ft) collected every six seconds at two stations (Santa Monica, CA (ID 9410840) and Coyote Creek, CA (ID 9414575)) over the period from August 18, 2015 through September 18, 2015.
+
+Note that the measurements `average_temperature`, `h2o_pH`, `h2o_quality`, and `h2o_temperature` contain fictional data. Those measurements are meant to make more explanatory the documentation in [Schema Exploration](../query_language/schema_exploration.html). 
+
+The `h2o_feet` measurement is the only measurement that contains the NOAA data. Please note that the `level description` field isn't part of the original NOAA data - we snuck it in there for the sake of having a field key with a special character and string [field values](../concepts/glossary.html#field-value).

--- a/content/docs/v0.9/sample_data/data_download.md
+++ b/content/docs/v0.9/sample_data/data_download.md
@@ -5,28 +5,22 @@ title: Sample data
 Download and write to InfluxDB the sample data used in [Data Exploration](../query_language/data_exploration.html), [Schema Exploration](../query_language/schema_exploration.html), and [Functions](../query_language/functions.html).
 
 ### Download and write the data to InfluxDB
-From your terminal, create the database `NOAA_water_database`:
-```
-curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE NOAA_water_database"
-```
+The following instructions are compatible with InfluxDB versions 0.9.5+.
 
-Download the text file that contains the data in [line protocol](https://influxdb.com/docs/v0.9/write_protocols/line.html) format:
+From your terminal, download the text file that contains the data in [line protocol](https://influxdb.com/docs/v0.9/write_protocols/line.html) format:
 ```
 curl https://s3-us-west-1.amazonaws.com/noaa.water.database.0.9/NOAA_data.txt > NOAA_data.txt
 ```
 
-Write the data to InfluxDB:
+Write the data to InfluxDB via the [CLI](../tools/shell.html):
 ```
-curl -i -XPOST "http://localhost:8086/write?db=NOAA_water_database&precision=s" --data-binary @NOAA_data.txt
+influx -import -path=NOAA_data.txt -precision=s
 ```
 
 ### Test queries
 See all five measurements:
-```sql
-> SHOW measurements
-```
-
 ```sh
+> SHOW measurements
 name: measurements
 ------------------
 name
@@ -38,11 +32,8 @@ h2o_temperature
 ```
 
 Count the number of non-null values of `water_level` in `h2o_feet`:
-```sql
-> SELECT COUNT(water_level) FROM h2o_feet
-```
-
 ```sh
+> SELECT COUNT(water_level) FROM h2o_feet
 name: h2o_feet
 --------------
 time			               count
@@ -51,11 +42,8 @@ time			               count
 
 Select the first ten observations in the measurement h2o_feet:
 
-```sql
-> SELECT * FROM h2o_feet LIMIT 10
-```
-
 ```sh
+> SELECT * FROM h2o_feet LIMIT 5
 name: h2o_feet
 --------------
 time			                 level description	      location	       water_level
@@ -64,15 +52,10 @@ time			                 level description	      location	       water_level
 2015-08-18T00:06:00Z	   between 6 and 9 feet	   coyote_creek	   8.005
 2015-08-18T00:06:00Z	   below 3 feet		          santa_monica	   2.116
 2015-08-18T00:12:00Z	   between 6 and 9 feet	   coyote_creek	   7.887
-2015-08-18T00:12:00Z	   below 3 feet		          santa_monica	   2.028
-2015-08-18T00:18:00Z	   between 6 and 9 feet	   coyote_creek	   7.762
-2015-08-18T00:18:00Z	   below 3 feet		          santa_monica	   2.126
-2015-08-18T00:24:00Z	   between 6 and 9 feet	   coyote_creek	   7.635
-2015-08-18T00:24:00Z	   below 3 feet		          santa_monica	   2.041
 ```
 
 ### Data sources and things to note
-The sample data are publicly available data from the [National Oceanic and Atmospheric Administration’s (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html?type=Water+Levels). The data include water levels (ft) collected every six seconds at two stations (Santa Monica, CA (ID 9410840) and Coyote Creek, CA (ID 9414575)) over the period from August 18, 2015 through September 18, 2015.
+The sample data are publicly available data from the [National Oceanic and Atmospheric Administration’s (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html?type=Water+Levels). The data include 15,258 observations of water levels (ft) collected every six seconds at two stations (Santa Monica, CA (ID 9410840) and Coyote Creek, CA (ID 9414575)) over the period from August 18, 2015 through September 18, 2015.
 
 Note that the measurements `average_temperature`, `h2o_pH`, `h2o_quality`, and `h2o_temperature` contain fictional data. Those measurements serve to illuminate query functionality in [Schema Exploration](../query_language/schema_exploration.html). 
 

--- a/content/docs/v0.9/sample_data/data_download.md
+++ b/content/docs/v0.9/sample_data/data_download.md
@@ -12,12 +12,12 @@ curl -G http://localhost:8086/query --data-urlencode "q=CREATE DATABASE NOAA_wat
 
 Download the text file that contains the data in [line protocol](https://influxdb.com/docs/v0.9/write_protocols/line.html) format:
 ```
-curl https://s3-us-west-1.amazonaws.com/noaa.water.database.0.9/NOAA_data.txt > NOAA_data1.txt
+curl https://s3-us-west-1.amazonaws.com/noaa.water.database.0.9/NOAA_data.txt > NOAA_data.txt
 ```
 
 Write the data to InfluxDB:
 ```
-curl -i -XPOST "http://localhost:8086/write?db=NOAA_water_database&precision=s" --data-binary @NOAA_data1.txt
+curl -i -XPOST "http://localhost:8086/write?db=NOAA_water_database&precision=s" --data-binary @NOAA_data.txt
 ```
 
 ### Test queries
@@ -72,8 +72,8 @@ time			                 level description	      location	       water_level
 ```
 
 ### Data sources and things to note
-We use publicly available data from the [National Oceanic and Atmospheric Administration’s (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html?type=Water+Levels). The data include water levels (ft) collected every six seconds at two stations (Santa Monica, CA (ID 9410840) and Coyote Creek, CA (ID 9414575)) over the period from August 18, 2015 through September 18, 2015.
+The sample data are publicly available data from the [National Oceanic and Atmospheric Administration’s (NOAA) Center for Operational Oceanographic Products and Services](http://tidesandcurrents.noaa.gov/stations.html?type=Water+Levels). The data include water levels (ft) collected every six seconds at two stations (Santa Monica, CA (ID 9410840) and Coyote Creek, CA (ID 9414575)) over the period from August 18, 2015 through September 18, 2015.
 
-Note that the measurements `average_temperature`, `h2o_pH`, `h2o_quality`, and `h2o_temperature` contain fictional data. Those measurements are meant to make more explanatory the documentation in [Schema Exploration](../query_language/schema_exploration.html). 
+Note that the measurements `average_temperature`, `h2o_pH`, `h2o_quality`, and `h2o_temperature` contain fictional data. Those measurements serve to illuminate query functionality in [Schema Exploration](../query_language/schema_exploration.html). 
 
 The `h2o_feet` measurement is the only measurement that contains the NOAA data. Please note that the `level description` field isn't part of the original NOAA data - we snuck it in there for the sake of having a field key with a special character and string [field values](../concepts/glossary.html#field-value).


### PR DESCRIPTION
I created a new page `data_download.md` which gives instructions for downloading and writing the sample data to InfluxDB.

`data_exploration`, `schema_exploration`, and `functions` link to that page.