### PR TITLE
removed references to POST with --data-urlencode

### DIFF
--- a/content/docs/v0.9/write_protocols/write_syntax.md
+++ b/content/docs/v0.9/write_protocols/write_syntax.md
@@ -230,7 +230,7 @@ curl -X POST 'http://localhost:8086/write?db=mydb&precision=ms' --data-binary 'd
 
 You can also pass a file using the `@` flag. The file can contain a batch of points, one per line. Points must be separated by newline characters `\n`. Batches should be 5000 points or fewer for best performance.
 
-`curl -X POST 'http://<hostname>:<port>/write?db=<database>' --data-binary @<filename>`
+`curl -X POST 'http://localhost:8086/write?db=<database>' --data-binary @<filename>`
 
 ### Caveats
 

--- a/content/docs/v0.9/write_protocols/write_syntax.md
+++ b/content/docs/v0.9/write_protocols/write_syntax.md
@@ -200,12 +200,6 @@ In this context, "valid node" means a node that hosts a copy of the shard contai
 curl -X POST 'http://localhost:8086/write?db=mydb' --data-binary 'disk_free,hostname=server01 value=442221834240i 1435362189575692182'
 ```
 
-You can also supply the query string parameters elsewhere in the command. They must be URL encoded:
-
-```bash
-curl -X POST 'http://localhost:8086/write' --data-urlencode 'db=mydb' --data-binary 'disk_free,hostname=server01 value=442221834240i 1435362189575692182'
-```
-
 #### Write a Point to a non-default Retention Policy
 
 Use the `rp=<retention_policy` query string parameter to supply a target retention policy. If not specified, the default retention policy for the target database will be used.
@@ -214,20 +208,12 @@ Use the `rp=<retention_policy` query string parameter to supply a target retenti
 curl -X POST 'http://localhost:8086/write?db=mydb&rp=six_month_rollup' --data-binary 'disk_free,hostname=server01 value=442221834240i 1435362189575692182'
 ```
 
-```bash
-curl -X POST 'http://localhost:8086/write' --data-urlencode 'db=mydb' --data-urlencode 'rp=six_month_rollup' --data-binary 'disk_free,hostname=server01 value=442221834240i 1435362189575692182'
-```
-
 #### Write a Point Using Authentication
 
 Use the `u=<user>` and `p=<password>` to pass the authentication details, if required.
 
 ```bash
 curl -X POST 'http://localhost:8086/write?db=mydb&u=root&p=123456' --data-binary 'disk_free,hostname=server01 value=442221834240i 1435362189575692182'
-```
-
-```bash
-curl -X POST 'http://localhost:8086/write' --data-urlencode 'db=mydb' --data-urlencode 'u=root&p=correct horse battery staple' --data-binary 'disk_free,hostname=server01 value=442221834240i 1435362189575692182'
 ```
 
 #### Specify Non-nanosecond Timestamps
@@ -240,19 +226,11 @@ All timestamps are assumed to be Unix nanoseconds unless otherwise specified. If
 curl -X POST 'http://localhost:8086/write?db=mydb&precision=ms' --data-binary 'disk_free value=442221834240i 1435362189575'
 ```
 
-```bash
-curl -X POST 'http://localhost:8086/write' --data-urlencode 'db=mydb&precision=s' --data-binary @points.txt
-```
-
 #### Write a Batch of Points with `curl`
 
 You can also pass a file using the `@` flag. The file can contain a batch of points, one per line. Points must be separated by newline characters `\n`. Batches should be 5000 points or fewer for best performance.
 
 `curl -X POST 'http://<hostname>:<port>/write?db=<database>' --data-binary @<filename>`
-
-```bash
-curl -X POST 'http://localhost:8086/write' --data-urlencode 'db=mydb&rp=myrp&u=root&p=root' --data-binary @points.txt
-```
 
 ### Caveats
 


### PR DESCRIPTION
Removed misleading references of curl commands using POST method while passing attributes with data-urlencode. This does not apply, as the string defined in data-urlencode when using a POST method is passed to the content instead of getting appended to the URL.


Troubleshooting and justification:
---
POST method with attributes defined in data-urlencode section. The string is not appended to the POST URL, rather it is added in the content along with the measurement data.

curl -vvvX POST 'http://localhost:8089/write' --data-urlencode 'db=mydb' --data-binary 'disk_free,hostname=server01 value=442221834240i'

[kostas@localhost ~]$ sudo nc -l -p 8089
POST /write HTTP/1.1
User-Agent: curl/7.29.0
Host: localhost:8089
Accept: */*
Content-Length: 55
Content-Type: application/x-www-form-urlencoded

db=mydb&disk_free,hostname=server01 value=442221834240i

---
POST method using attributes originally appended to the URL which does work:

curl -vvvX POST 'http://localhost:8089/write?db=mydb' --data-binary 'disk_free,hostname=server01 value=442221834240i'

[kostas@localhost ~]$ sudo nc -l -p 8089
POST /write?db=mydb HTTP/1.1
User-Agent: curl/7.29.0
Host: localhost:8089
Accept: */*
Content-Length: 47
Content-Type: application/x-www-form-urlencoded

disk_free,hostname=server01 value=442221834240i

---
GET method appends data-urlencode content to the URL but can't be used to write data with the HTTP API.

curl -G 'http://localhost:8089/write' --data-urlencode 'db=mydb' --data-binary 'disk_free,hostname=server01 value=442221834240i'

[kostas@localhost ~]$ sudo nc -l -p 8089
GET /write?db=mydb&disk_free,hostname=server01 value=442221834240i HTTP/1.1
User-Agent: curl/7.29.0
Host: localhost:8089
Accept: */*