### PR TITLE
Add an extended discussion about the CQ configuration options

### DIFF
--- a/content/docs/v0.9/query_language/continuous_queries_config.md
+++ b/content/docs/v0.9/query_language/continuous_queries_config.md
@@ -1,0 +1,158 @@
+---
+title: Configuring continuous queries
+---
+
+A continuous query (CQ) is an automated query that executes over recent time intervals. When InfluxDB executes a CQ it computes the query for the current `GROUP BY time()` interval (determined by `now()`) and it computes the query for previous `GROUP BY time()` intervals.
+
+The rate at which InfluxDB executes a CQ and the number of previous time intervals that InfluxDB queries depend on the CQ's `GROUP BY time()` interval and on the following configuration options (shown with their default settings):
+
+* `compute-runs-per-interval = 10`
+* `compute-no-more-than = "2m0s"`
+* `recompute-previous-n =  2`
+* `recompute-no-older-than = "10m0s"`
+
+InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes a CQ. Under the first setting, InfluxDB executes the CQ `10` times per the `GROUP BY time()` interval. Under the second setting, InfluxDB executes the CQ every `2` minutes; this is the minimum rate at which InfluxDB executes a CQ.
+
+InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes a CQ. Under the first setting, InfluxDB queries `2` previous intervals. Under the second setting, InfluxDB queries all previous intervals within `now()` - `10` minutes. InfluxDB queries the smaller of the two options when it executes a CQ.
+
+Depending on your CQ's `GROUP BY time()` interval you may want to make changes to the default configuration settings. The next sections present example CQs and discuss how they work with the configuration options:
+
+* [CQ 1](../query_language/continuous_queries_config.html#cq-1-4-minute-group-by-time-interval) is an introductory example CQ that shows how the default configuration settings work with a CQ's `GROUP BY time()` interval. 
+* [CQ 2](../query_language/continuous_queries_config.html#cq-2-30-second-group-by-time-interval) is an example of a CQ with a shorter term `GROUP BY time()` interval that doesn't work well with the default configuration settings. This section also covers how to alter the configuration settings to fix the issue.
+* [CQ 3](../query_language/continuous_queries_config.html#cq-3-1-hour-group-by-time-interval) is an example of a CQ with a longer term `GROUP BY time()` interval. This section shows how to alter the configuration settings to take into account lagged data.
+
+## CQ 1: 4 minute `GROUP BY time()` interval
+### The default CQ schedule
+Default configuration settings:  
+`compute-runs-per-interval = 10`  
+`compute-no-more-than = "2m0s"`  
+`recompute-previous-n = 2`  
+`recompute-no-older-than = "10m0s"`  
+
+*InfluxDB executes CQ 1 every 2 minutes.*
+
+InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes CQ 1. Under `compute-runs-per-interval`, InfluxDB executes CQ 1 every `0.4` minutes (`4m`/`10`). Under `compute-no-more-than`, InfluxDB executes the CQ every `2` minutes. Because `compute-no-more-than` is the minimum rate at which InfluxDB executes a CQ, CQ 1 runs every `2` minutes.
+
+*InfluxDB computes queries for 2 previous intervals in addition to computing the query for the current time interval.*
+
+InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 1. Under `recompute-previous-n`, InfluxDB queries `2` previous intervals. Under `recompute-no-older-than`, InfluxDB queries, at most, `3`<sup>[*](#note1)</sup> previous intervals (`10m0s`/`4m` = `2.5`). InfluxDB queries the smaller of the two options when it executes CQ 1.
+
+> <a name="note1"></a>**Note:** InfluxDB rounds up to the next complete interval if the `GROUP BY time()` interval doesn't divide evenly into `recompute-no-older-than`.
+
+## CQ 2: 30 second `GROUP BY time()` interval
+### The default CQ schedule
+Default configuration settings:  
+`compute-runs-per-interval = 10`  
+`compute-no-more-than = "2m0s"`  
+`recompute-previous-n = 2`  
+`recompute-no-older-than = "10m0s"`  
+
+*InfluxDB executes CQ 2 every 2 minutes.*
+
+InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes CQ 2. Under `compute-runs-per-interval`, InfluxDB executes CQ 2 every `3` seconds (`30s`/`10`). Under `compute-no-more-than`, InfluxDB executes the CQ every `2` minutes. Because `compute-no-more-than` is the minimum rate at which InfluxDB executes a CQ, CQ 2 runs every `2` minutes.
+
+*InfluxDB computes queries for 2 previous intervals in addition to computing the query for the current time interval.*
+
+InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 2. Under `recompute-previous-n`, InfluxDB queries `2` previous intervals. Under `recompute-no-older-than`, InfluxDB queries, at most, `20` previous intervals (`600s`/`30s` = `20`). InfluxDB queries the smaller of the two options when it executes CQ 2.
+
+#### The missing interval problem
+Because of CQ 2's small `GROUP BY time()` interval, leaving the default configuration settings as is causes InfluxDB to miss intervals. 
+
+Assume CQ 2 begins running at midnight. InfluxDB computes the query for the following three time intervals:  
+Current interval: `00:00:00` - `00:00:30`  
+Previous interval 1: `00:59:30` - `00:00:00`  
+Previous interval 2: `00:59:00` - `00:59:30`  
+
+Two minutes later, InfluxDB executes the query for the following three time intervals:  
+Current interval: `00:02:00` - `00:02:30`  
+Previous interval 1: `00:01:30` - `00:02:00`  
+Previous interval 2: `00:01:00` - `00:01:30`
+
+Notice that InfluxDB never executes the query for the time interval from `00:00:30` through `00:01:00`. The next two sections offer different ways to solve the missing interval problem.
+
+### Change the execution rate
+New configuration settings:  
+`compute-runs-per-interval = 10`  
+`compute-no-more-than = "1m30s"`  
+
+*InfluxDB now executes CQ 2 every 1.5 minutes.*
+
+InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes CQ 2. Under `compute-runs-per-interval`, InfluxDB executes CQ 2 every `3` seconds (`30s`/`10`). Under `compute-no-more-than`, InfluxDB executes the CQ every `1.5` minutes. Because `compute-no-more-than` is the minimum rate at which InfluxDB executes a CQ, CQ 2 runs every `1.5` minutes.
+
+The new configuration settings prevent InfluxDB from missing intervals by increasing the frequency at which CQ 2 runs from every `2` minutes to every `1.5` minutes. Assuming CQ 2 begins running at midnight,  InfluxDB computes the query for the following three time intervals:  
+Current interval: `00:00:00` - `00:00:30`  
+Previous interval 1: `00:59:30` - `00:00:00`  
+Previous interval 2: `00:59:00` - `00:59:30`  
+
+`1.5` minutes later, InfluxDB computes the query for the following three time intervals:  
+Current interval: `00:01:30` - `00:02:00`  
+Previous interval 1: `00:01:00` - `00:01:30`  
+Previous interval 2: `00:00:30` - `00:01:00`
+
+Notice that InfluxDB now computes the query for the time interval from `00:00:30` through `00:01:00`.
+
+### Change the number of previous intervals queried
+New configuration settings:    
+`recompute-previous-n = 3`  
+`recompute-no-older-than = "10m0s"`  
+
+*InfluxDB now computes queries for 3 previous intervals in addition to computing the query for the current time interval.*
+
+InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 2. Under `recompute-previous-n`, InfluxDB queries `3` previous intervals. Under `recompute-no-older-than`, InfluxDB queries, at most, `20` previous intervals (`600s`/`30s` = `20`). InfluxDB queries the smaller of the two options when it executes CQ 2.
+
+The new settings prevent InfluxDB from missing intervals by increasing the number of intervals it computes from `2` to `3`. Assuming CQ 2 begins running at midnight,  InfluxDB computes the query for the following four time intervals:  
+Current interval: `00:00:00` - `00:00:30`  
+Previous interval 1: `00:59:30` - `00:00:00`  
+Previous interval 2: `00:59:00` - `00:59:30`  
+Previous interval 3: `00:58:30` - `00:59:00`  
+
+`2` minutes later, InfluxDB executes the query for the following four time intervals:  
+Current interval: `00:02:00` - `00:02:30`  
+Previous interval 1: `00:01:30` - `00:02:00`  
+Previous interval 2: `00:01:00` - `00:01:30`  
+Previous interval 2: `00:00:30` - `00:01:00`  
+
+Notice that InfluxDB now computes the query for the time interval from `00:00:30` through `00:01:00`.
+
+## CQ 3: 1 hour `GROUP BY time()` interval
+### The default CQ schedule
+Default configuration settings:   
+`compute-runs-per-interval = 10`  
+`compute-no-more-than = "2m0s"`  
+`recompute-previous-n = 2`  
+`recompute-no-older-than = "10m0s"`  
+
+*InfluxDB executes CQ 3 every 6 minutes.*
+
+InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes CQ 3. Under `compute-runs-per-interval`, InfluxDB executes the CQ every `6` minutes (`60m`/`10`). Under `compute-no-more-than`, InfluxDB executes the CQ every `2` minutes. Because the execution rate under `compute-runs-per-interval` is greater than that under `compute-no-more-than`, CQ 3 runs every `6` minutes.
+
+*InfluxDB computes queries for, at most, 1 previous interval in addition to computing the query for the current time interval.*
+
+InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 3. Under `recompute-previous-n`, InfluxDB queries `2` previous intervals. Under `recompute-no-older-than`, InfluxDB queries, at most, `1`<sup>[*](#note2)</sup> previous interval (`10m0s`/`60m` = `0.167`). InfluxDB queries the smaller of the two options when it executes CQ 3.
+
+> <a name="note2"></a>**Note:** InfluxDB rounds up to the next complete interval if the `GROUP BY time()` interval doesn't divide evenly into `recompute-no-older-than`.
+
+#### The lagged data problem
+InfluxDB computes one previous interval if `now()` - `10` minutes falls in the previous interval. 
+
+If CQ 3 runs at `13:58:00` InfluxDB computes the query for all data between `13:00:00` and `14:00:00`. It does not compute the query for the previous interval (`12:00:00` - `13:00:00`) because `13:48:00` (`13:58:00` - `10` minutes) does not fall in that interval.
+
+InfluxDB executes CQ 3 six minutes later at `14:04:00`. It computes the query for the current time interval (`14:00:00` - `15:00:00`) and for one previous time interval (`13:00:00` - `14:00:00`). It computes the query for the previous time interval because `13:54:00` (`14:04:00` - `10` minutes) falls in the previous interval.
+
+At `14:10:00`, InfluxDB executes CQ 3 and computes the query for the current time interval (`14:00:00` - `15:00:00`). It does not compute the query for the previous time interval because `14:00:00` (`14:10:00` - `10` minutes) does not fall in the previous interval.
+
+If you have lagged data, computing, at most, `1` previous interval may not take into account all of your data. See the next section for how to adjust the configuration settings so that InfluxDB always computes the query for the previous time interval when it executes CQ 3.
+
+### Change the number of previous intervals queried
+New configuration settings:  
+`recompute-previous-n = 1`  
+`recompute-no-older-than = 120m0s`  
+
+*InfluxDB always computes the query for 1 previous interval in addition to computing the query for the current time interval.*
+
+InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 3. Under `recompute-previous-n`, InfluxDB queries `1` previous interval. Under `recompute-no-older-than`, InfluxDB queries, at most, `2` previous intervals (`120m0s`/`60m` = `2`). InfluxDB queries the smaller of the two options when it executes CQ 3.
+
+The new settings ensure that InfluxDB always computes the query for the current time interval and for one previous time interval.
+
+
+

--- a/content/docs/v0.9/query_language/continuous_queries_config.md
+++ b/content/docs/v0.9/query_language/continuous_queries_config.md
@@ -2,18 +2,37 @@
 title: Configuring continuous queries
 ---
 
-A continuous query (CQ) is an automated query that executes over recent time intervals. When InfluxDB executes a CQ it computes the query for the current `GROUP BY time()` interval (determined by `now()`) and it computes the query for previous `GROUP BY time()` intervals.
+## What is a continuous query?
+A continuous query (CQ) is an InfluxQL query that the system periodically executes in batches. 
 
-The rate at which InfluxDB executes a CQ and the number of previous time intervals that InfluxDB queries depend on the CQ's `GROUP BY time()` interval and on the following configuration options (shown with their default settings):
+Each batch contains one or more queries where each query covers a single `GROUP BY time()` interval. InfluxDB always generates a query for the current `GROUP BY time()` interval (determined by `now()`) and it generates zero or more queries for recent `GROUP BY time()` intervals.
+
+The time ranges of the generated queries have round-number boundaries. For example, if the CQ's `GROUP BY time()` interval is 30 minutes long, the queries' start and end times (in `MM:SS`) are always `00:00` or `30:00`.
+
+## The CQ schedule
+The rate at which InfluxDB generates batches of queries and the number of queries generated per batch depend on the CQ's `GROUP BY time()` interval and on the following configuration options (shown with their default settings):
 
 * `compute-runs-per-interval = 10`
 * `compute-no-more-than = "2m0s"`
 * `recompute-previous-n =  2`
 * `recompute-no-older-than = "10m0s"`
 
-InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes a CQ. Under the first setting, InfluxDB executes the CQ `10` times per the `GROUP BY time()` interval. Under the second setting, InfluxDB executes the CQ every `2` minutes; this is the minimum rate at which InfluxDB executes a CQ.
+### Frequency of batch creation
 
-InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes a CQ. Under the first setting, InfluxDB queries `2` previous intervals. Under the second setting, InfluxDB queries all previous intervals within `now()` - `10` minutes. InfluxDB queries the smaller of the two options when it executes a CQ.
+InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it generates batches for a CQ. `compute-runs-per-interval` is the upper bound of the number of incremental queries generated per `GROUP BY time()` interval. `compute-no-more-than` is the maximum frequency at which InfluxDB generates batches. `compute-no-more-than` takes precedence over `compute-runs-per-interval`.
+
+In the default settings, InfluxDB generates batches for a CQ as often as  `10` times per the `GROUP BY time()` interval. However, it will not generate batches more often than every two minutes, regardless of the value of `GROUP BY  time()` divided by 10.
+
+For example, if the CQ has a `30m` `GROUP BY time()` interval, then `compute-runs-per-interval` sets a maximum batch frequency of `3m`, since `30m` / 10 = `3m`. This is less frequent than the maximum frequency of `2m`, as set by `compute-no-more-than`, so the system generates a batch of that CQ every `3m`.
+
+If the CQ has a `30s` `GROUP BY time()` interval, then `compute-runs-per-interval` sets a maximum batch frequency of `3s`, since `30s` / 10 = `3s`. However, `compute-no-more-than` takes precedence and thus the system generates batches every `2m`.
+
+### Number of queries per batch
+InfluxDB uses `recompute-previous-n` and `recompute-no-older-than` to determine the number queries generated per batch for a CQ. All batches include at least one generated query with the time range that spans `now()`. The maximum number of additional queries with time ranges that span intervals prior to `now()` is determined by `recompute-previous-n`. Therefore `recompute-previous-n` + 1 is the maximum number of queries per batch. `recompute-no-older-than` puts a limit on the age of the previous query interval, such that the upper boundary  of each generated query must be greater than `now()` - `recompute-no-older-than`. `recompute-no-older-than` takes precedence over `recompute-previous-n`.
+
+In the default settings, InfluxDB generates at most three queries per batch: one spanning `now()` and up to two queries spanning older time intervals, as set by `recompute-previous-n`. In addition, the upper boundary of the query time range for each generated query must be less than `10m` in the past.
+
+For example, if the CQ has a `30s` `GROUP BY time()` interval, then InfluxDB generates three queries for each batch. However, if the CQ has a `30m` `GROUP BY time` interval, then InfluxDB generates only one or two queries for a given batch, since the third query would have an upper boundary at least `30m` in the past, which exceeds the `recompute-no-older-than` setting.
 
 Depending on your CQ's `GROUP BY time()` interval you may want to make changes to the default configuration settings. The next sections present example CQs and discuss how they work with the configuration options:
 
@@ -22,6 +41,13 @@ Depending on your CQ's `GROUP BY time()` interval you may want to make changes t
 * [CQ 3](../query_language/continuous_queries_config.html#cq-3-1-hour-group-by-time-interval) is an example of a CQ with a longer term `GROUP BY time()` interval. This section shows how to alter the configuration settings to take into account lagged data.
 
 ## CQ 1: 4 minute `GROUP BY time()` interval
+### Create CQ 1
+```sql
+CREATE CONTINUOUS QUERY cq1 ON telegraf BEGIN SELECT MEAN(value) INTO cq_4m FROM cpu_usage_idle WHERE cpu='cpu-total' GROUP BY time(4m) END
+```
+
+For our purposes the only important part of that statement is the `4m` `GROUP BY time()` interval. For more on the syntax for creating CQs, see [Continuous Queries](../query_language/continuous_queries.html).
+
 ### The default CQ schedule
 Default configuration settings:  
 `compute-runs-per-interval = 10`  
@@ -29,17 +55,43 @@ Default configuration settings:
 `recompute-previous-n = 2`  
 `recompute-no-older-than = "10m0s"`  
 
-*InfluxDB executes CQ 1 every 2 minutes.*
+*InfluxDB generates batches of CQ 1 every 2 minutes.*
 
-InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes CQ 1. Under `compute-runs-per-interval`, InfluxDB executes CQ 1 every `0.4` minutes (`4m`/`10`). Under `compute-no-more-than`, InfluxDB executes the CQ every `2` minutes. Because `compute-no-more-than` is the minimum rate at which InfluxDB executes a CQ, CQ 1 runs every `2` minutes.
+`compute-runs-per-interval` sets a maximum batch frequency of `0.4m`, since `4m` /  `10` = `0.4m`. This is more frequent than the maximum frequency of `2m`, as set by `compute-no-more-than`, so the system generates a batch of CQ 1 every `2m`.
 
-*InfluxDB computes queries for 2 previous intervals in addition to computing the query for the current time interval.*
+*InfluxDB generates 3 queries per batch of CQ 1.*
 
-InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 1. Under `recompute-previous-n`, InfluxDB queries `2` previous intervals. Under `recompute-no-older-than`, InfluxDB queries, at most, `3`<sup>[*](#note1)</sup> previous intervals (`10m0s`/`4m` = `2.5`). InfluxDB queries the smaller of the two options when it executes CQ 1.
+InfluxDB generates one query that spans `now()` and two additional queries that span older time intervals because `recompute-no-older-than` (`10m`) always falls within the time range covered by `recompute-previous-n` (`2` intervals * `4m` = `8m`).
 
-> <a name="note1"></a>**Note:** InfluxDB rounds up to the next complete interval if the `GROUP BY time()` interval doesn't divide evenly into `recompute-no-older-than`.
+### CQ 1 in practice
+A sample of CQ 1's frequency of batch creation and the number of queries per batch on 2015/11/24 starting at 18:19:45 (UTC):
+
+InfluxDB generates three queries at 18:19:45:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_4m FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T18:16:00Z' AND time < '2015-11-24T18:20:00Z' GROUP BY time(4m)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_4m FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T18:12:00Z' AND time < '2015-11-24T18:16:00Z' GROUP BY time(4m)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_4m FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T18:08:00Z' AND time < '2015-11-24T18:12:00Z' GROUP BY time(4m)
+```
+InfluxDB generates another three queries two minutes later at 18:21:45:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_4m FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T18:20:00Z' AND time < '2015-11-24T18:24:00Z' GROUP BY time(4m)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_4m FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T18:16:00Z' AND time < '2015-11-24T18:20:00Z' GROUP BY time(4m)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_4m FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T18:12:00Z' AND time < '2015-11-24T18:16:00Z' GROUP BY time(4m)
+```
+
+In both cases, the first query has the relevant time range that spans `now()`: 18:19:45 falls within the four minute interval between 18:16:00 and 18:20:00, and 18:21:45 falls within the four minute interval between 18:20:00 and 18:24:00. The second two queries span older four minute time intervals. Notice that the queries that cover the time ranges 18:16:00 through 18:20:00 and 18:12:00 through 18:16:00 appear in both the first batch of generated queries and in the second batch of generated queries.  
 
 ## CQ 2: 30 second `GROUP BY time()` interval
+### Create CQ 2
+```sql
+CREATE CONTINUOUS QUERY cq2 ON telegraf BEGIN SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' GROUP BY time(30s) END
+```
+For our purposes the only important part of that statement is the `30s` `GROUP BY time()` interval. For more on the syntax for creating CQs, see [Continuous Queries](../query_language/continuous_queries.html).
+
 ### The default CQ schedule
 Default configuration settings:  
 `compute-runs-per-interval = 10`  
@@ -47,74 +99,109 @@ Default configuration settings:
 `recompute-previous-n = 2`  
 `recompute-no-older-than = "10m0s"`  
 
-*InfluxDB executes CQ 2 every 2 minutes.*
+*InfluxDB generates batches of CQ 2 every 2 minutes.*
 
-InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes CQ 2. Under `compute-runs-per-interval`, InfluxDB executes CQ 2 every `3` seconds (`30s`/`10`). Under `compute-no-more-than`, InfluxDB executes the CQ every `2` minutes. Because `compute-no-more-than` is the minimum rate at which InfluxDB executes a CQ, CQ 2 runs every `2` minutes.
+`compute-runs-per-interval` sets a maximum batch frequency of `3s`, since `30s` /  `10` = `3s`. This is more frequent than the maximum frequency of `2m`, as set by `compute-no-more-than`, so the system generates a batch of CQ 2 every `2m`.
 
-*InfluxDB computes queries for 2 previous intervals in addition to computing the query for the current time interval.*
+*InfluxDB generates 3 queries per batch of CQ 2.*
 
-InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 2. Under `recompute-previous-n`, InfluxDB queries `2` previous intervals. Under `recompute-no-older-than`, InfluxDB queries, at most, `20` previous intervals (`600s`/`30s` = `20`). InfluxDB queries the smaller of the two options when it executes CQ 2.
+InfluxDB generates one query that spans `now()` and two additional queries that span older time intervals because `recompute-no-older-than` (`10m`) always falls within the time range covered by `recompute-previous-n` (`2` intervals * `30s` = `1m`).
 
-#### The missing interval problem
-Because of CQ 2's small `GROUP BY time()` interval, leaving the default configuration settings as is causes InfluxDB to miss intervals. 
+### CQ 2 in practice
+A sample of CQ 2’s frequency of batch creation and the number of queries per batch on 2015/11/24 starting at 19:41:17 (UTC):
 
-Assume CQ 2 begins running at midnight. InfluxDB computes the query for the following three time intervals:  
-Current interval: `00:00:00` - `00:00:30`  
-Previous interval 1: `00:59:30` - `00:00:00`  
-Previous interval 2: `00:59:00` - `00:59:30`  
+InfluxDB generates three queries at 19:41:17:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:41:00Z' AND time < '2015-11-24T19:41:30Z' GROUP BY time(30s)
 
-Two minutes later, InfluxDB executes the query for the following three time intervals:  
-Current interval: `00:02:00` - `00:02:30`  
-Previous interval 1: `00:01:30` - `00:02:00`  
-Previous interval 2: `00:01:00` - `00:01:30`
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:40:30Z' AND time < '2015-11-24T19:41:00Z' GROUP BY time(30s)
 
-Notice that InfluxDB never executes the query for the time interval from `00:00:30` through `00:01:00`. The next two sections offer different ways to solve the missing interval problem.
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:40:00Z' AND time < '2015-11-24T19:40:30Z' GROUP BY time(30s)
+```
+InfluxDB generates another three queries two minutes later at 19:43:17:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:43:00Z' AND time < '2015-11-24T19:43:30Z' GROUP BY time(30s)
 
-### Change the execution rate
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:42:30Z' AND time < '2015-11-24T19:43:00Z' GROUP BY time(30s)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:42:00Z' AND time < '2015-11-24T19:42:30Z' GROUP BY time(30s)
+```
+
+In both cases, the first query has the revelant time range that spans `now()`: 19:41:17 falls within the 30 second interval between 19:41:00 and 19:41:30, and 19:43:17 falls within the 30 second interval between 19:43:00 and 19:43:30. The second two queries span older 30 second time intervals. 
+
+Because of CQ 2's small `GROUP BY time()` interval, leaving the default configuration settings as is causes InfluxDB to skip a 30 second interval. In the example above, the system never queries the time range between 19:41:30 and 19:42:00. The next two sections offer different ways to solve the missing interval problem.
+
+### Change the frequency of batch creation
 New configuration settings:  
 `compute-runs-per-interval = 10`  
 `compute-no-more-than = "1m30s"`  
 
-*InfluxDB now executes CQ 2 every 1.5 minutes.*
+*InfluxDB now generates batches of CQ 2 every 1.5 minutes.*
 
-InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes CQ 2. Under `compute-runs-per-interval`, InfluxDB executes CQ 2 every `3` seconds (`30s`/`10`). Under `compute-no-more-than`, InfluxDB executes the CQ every `1.5` minutes. Because `compute-no-more-than` is the minimum rate at which InfluxDB executes a CQ, CQ 2 runs every `1.5` minutes.
+`compute-runs-per-interval` sets a maximum batch frequency of `3s`, since `30s` /  `10` = `3s`. This is more frequent than the maximum frequency of `1.5m`, as set by `compute-no-more-than`, so the system generates a batch of CQ 2 every `1.5m`.
 
-The new configuration settings prevent InfluxDB from missing intervals by increasing the frequency at which CQ 2 runs from every `2` minutes to every `1.5` minutes. Assuming CQ 2 begins running at midnight,  InfluxDB computes the query for the following three time intervals:  
-Current interval: `00:00:00` - `00:00:30`  
-Previous interval 1: `00:59:30` - `00:00:00`  
-Previous interval 2: `00:59:00` - `00:59:30`  
+Now a sample of CQ 2’s frequency of batch creation and the number of queries per batch on 2015/11/24 starting at 19:41:17 (UTC) looks like this:
 
-`1.5` minutes later, InfluxDB computes the query for the following three time intervals:  
-Current interval: `00:01:30` - `00:02:00`  
-Previous interval 1: `00:01:00` - `00:01:30`  
-Previous interval 2: `00:00:30` - `00:01:00`
+InfluxDB generates three queries at 19:41:17:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:41:00Z' AND time < '2015-11-24T19:41:30Z' GROUP BY time(30s)
 
-Notice that InfluxDB now computes the query for the time interval from `00:00:30` through `00:01:00`.
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:40:30Z' AND time < '2015-11-24T19:41:00Z' GROUP BY time(30s)
 
-### Change the number of previous intervals queried
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:40:00Z' AND time < '2015-11-24T19:40:30Z' GROUP BY time(30s)
+```
+InfluxDB generates another three queries 1.5 minutes later at 19:42:47:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:42:30Z' AND time < '2015-11-24T19:43:00Z' GROUP BY time(30s)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:42:00Z' AND time < '2015-11-24T19:42:30Z' GROUP BY time(30s)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:41:30Z' AND time < '2015-11-24T19:42:00Z' GROUP BY time(30s)
+```
+
+Notice that because of the new frequency of batch creation, InfluxDB no longer misses the query that covers the time range from 19:41:30 through 19:42:00.
+
+### Change the number of queries per batch
 New configuration settings:    
 `recompute-previous-n = 3`  
 `recompute-no-older-than = "10m0s"`  
 
-*InfluxDB now computes queries for 3 previous intervals in addition to computing the query for the current time interval.*
+*InfluxDB generates 4 queries per batch of CQ 2.*
 
-InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 2. Under `recompute-previous-n`, InfluxDB queries `3` previous intervals. Under `recompute-no-older-than`, InfluxDB queries, at most, `20` previous intervals (`600s`/`30s` = `20`). InfluxDB queries the smaller of the two options when it executes CQ 2.
+InfluxDB generates one query that spans `now()` and three additional queries that span older time intervals because `recompute-no-older-than` (`10m`) always falls within the time range covered by `recompute-previous-n` (`3` intervals * `30s` = `1.5m`).
 
-The new settings prevent InfluxDB from missing intervals by increasing the number of intervals it computes from `2` to `3`. Assuming CQ 2 begins running at midnight,  InfluxDB computes the query for the following four time intervals:  
-Current interval: `00:00:00` - `00:00:30`  
-Previous interval 1: `00:59:30` - `00:00:00`  
-Previous interval 2: `00:59:00` - `00:59:30`  
-Previous interval 3: `00:58:30` - `00:59:00`  
+Now a sample of CQ 2’s frequency of batch creation and the number of queries per batch on 2015/11/24 starting at 19:41:17 (UTC) looks like this:
 
-`2` minutes later, InfluxDB executes the query for the following four time intervals:  
-Current interval: `00:02:00` - `00:02:30`  
-Previous interval 1: `00:01:30` - `00:02:00`  
-Previous interval 2: `00:01:00` - `00:01:30`  
-Previous interval 2: `00:00:30` - `00:01:00`  
+InfluxDB generates four queries at 19:41:17:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:41:00Z' AND time < '2015-11-24T19:41:30Z' GROUP BY time(30s)
 
-Notice that InfluxDB now computes the query for the time interval from `00:00:30` through `00:01:00`.
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:40:30Z' AND time < '2015-11-24T19:41:00Z' GROUP BY time(30s)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:40:00Z' AND time < '2015-11-24T19:40:30Z' GROUP BY time(30s)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:39:30Z' AND time < '2015-11-24T19:40:00Z' GROUP BY time(30s)
+```
+InfluxDB generates another four queries two minutes later at 19:43:17:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:43:00Z' AND time < '2015-11-24T19:43:30Z' GROUP BY time(30s)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:42:30Z' AND time < '2015-11-24T19:43:00Z' GROUP BY time(30s)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:42:00Z' AND time < '2015-11-24T19:42:30Z' GROUP BY time(30s)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_30s FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T19:41:30Z' AND time < '2015-11-24T19:42:00Z' GROUP BY time(30s)
+```
+
+Notice that because of the new number of queries per batch, InfluxDB no longer misses the query that covers the time range from 19:41:30 through 19:42:00.
 
 ## CQ 3: 1 hour `GROUP BY time()` interval
+### Create CQ 3
+```sql
+CREATE CONTINUOUS QUERY cq3 ON telegraf BEGIN SELECT MEAN(value) INTO cq_1h FROM cpu_usage_idle WHERE cpu='cpu-total' GROUP BY time(1h) END
+```
+For our purposes the only important part of that statement is the `1h` `GROUP BY time()` interval. For more on the syntax for creating CQs, see [Continuous Queries](../query_language/continuous_queries.html).
+
 ### The default CQ schedule
 Default configuration settings:   
 `compute-runs-per-interval = 10`  
@@ -122,37 +209,57 @@ Default configuration settings:
 `recompute-previous-n = 2`  
 `recompute-no-older-than = "10m0s"`  
 
-*InfluxDB executes CQ 3 every 6 minutes.*
+*InfluxDB generates batches of CQ 3 every 6 minutes.*
 
-InfluxDB compares `compute-runs-per-interval` and `compute-no-more-than` to determine the rate at which it executes CQ 3. Under `compute-runs-per-interval`, InfluxDB executes the CQ every `6` minutes (`60m`/`10`). Under `compute-no-more-than`, InfluxDB executes the CQ every `2` minutes. Because the execution rate under `compute-runs-per-interval` is greater than that under `compute-no-more-than`, CQ 3 runs every `6` minutes.
+`compute-runs-per-interval` sets a maximum batch frequency of `6m`, since `60m` /  `10` = `6m`. This is less frequent than the maximum frequency of `2m`, as set by `compute-no-more-than`, so the system generates a batch of CQ 3 every `6m`.
 
-*InfluxDB computes queries for, at most, 1 previous interval in addition to computing the query for the current time interval.*
+*InfluxDB generates at most 2 queries per batch of CQ 3.*
 
-InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 3. Under `recompute-previous-n`, InfluxDB queries `2` previous intervals. Under `recompute-no-older-than`, InfluxDB queries, at most, `1`<sup>[*](#note2)</sup> previous interval (`10m0s`/`60m` = `0.167`). InfluxDB queries the smaller of the two options when it executes CQ 3.
+InfluxDB generates one query that spans `now()` and at most 1 additional query that spans an older time interval because the third query would have an upper boundary at least `1h` in the past, which exceeds the `recompute-no-older-than` (`10m`) setting.
 
-> <a name="note2"></a>**Note:** InfluxDB rounds up to the next complete interval if the `GROUP BY time()` interval doesn't divide evenly into `recompute-no-older-than`.
+### CQ 3 in practice
+A sample of CQ 3’s frequency of batch creation and the number of queries per batch on 2015/11/24 starting at 22:09:55 (UTC):
 
-#### The lagged data problem
-InfluxDB computes one previous interval if `now()` - `10` minutes falls in the previous interval. 
+InfluxDB generates two queries at 22:09:55:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_1h FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T22:00:00Z' AND time < '2015-11-24T23:00:00Z' GROUP BY time(1h)
 
-If CQ 3 runs at `13:58:00` InfluxDB computes the query for all data between `13:00:00` and `14:00:00`. It does not compute the query for the previous interval (`12:00:00` - `13:00:00`) because `13:48:00` (`13:58:00` - `10` minutes) does not fall in that interval.
+SELECT MEAN(value) INTO "telegraf"."default".cq_1h FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T21:00:00Z' AND time < '2015-11-24T22:00:00Z' GROUP BY time(1h)
+```
+InfluxDB generates one query six minutes later at 22:15:55:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_1h FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T22:00:00Z' AND time < '2015-11-24T23:00:00Z' GROUP BY time(1h)
+```
 
-InfluxDB executes CQ 3 six minutes later at `14:04:00`. It computes the query for the current time interval (`14:00:00` - `15:00:00`) and for one previous time interval (`13:00:00` - `14:00:00`). It computes the query for the previous time interval because `13:54:00` (`14:04:00` - `10` minutes) falls in the previous interval.
+At 22:09:55, InfluxDB generates two queries; one query covers the time range that spans `now()` and one query covers the previous `GROUP BY time()` interval. InfluxDB generates the second query because  `now()` - `10m` falls in the previous `GROUP BY time()` interval (22:09:55 -  `10m` = 21:59:55). 
 
-At `14:10:00`, InfluxDB executes CQ 3 and computes the query for the current time interval (`14:00:00` - `15:00:00`). It does not compute the query for the previous time interval because `14:00:00` (`14:10:00` - `10` minutes) does not fall in the previous interval.
+At 22:15:55, InfluxDB generates only one query. That query covers the time range that spans `now()`. InfluxDB doesn't generate a second query because `now()` - `10m` falls in the interval that spans `now()` (22:15:55 - `10m` = 22:05:55).
 
-If you have lagged data, computing, at most, `1` previous interval may not take into account all of your data. See the next section for how to adjust the configuration settings so that InfluxDB always computes the query for the previous time interval when it executes CQ 3.
+If you have lagged data, generating, at most, one query for a previous interval may not take into account all of your data. The next section offers one way to adjust the configuration settings so that a query batch always includes a query for one previous time interval.
 
 ### Change the number of previous intervals queried
 New configuration settings:  
 `recompute-previous-n = 1`  
 `recompute-no-older-than = 120m0s`  
 
-*InfluxDB always computes the query for 1 previous interval in addition to computing the query for the current time interval.*
+*InfluxDB generates 2 queries per batch of CQ 3.*
 
-InfluxDB compares `recompute-previous-n` and `recompute-no-older-than` to determine the number of previous intervals it queries when it executes CQ 3. Under `recompute-previous-n`, InfluxDB queries `1` previous interval. Under `recompute-no-older-than`, InfluxDB queries, at most, `2` previous intervals (`120m0s`/`60m` = `2`). InfluxDB queries the smaller of the two options when it executes CQ 3.
+InfluxDB generates one query that spans `now()` and one additional query that spans an older time interval because `recompute-no-older-than` (`120m`) always falls within the time range covered by `recompute-previous-n` (`1` intervals * `1h` = `60m`).
 
-The new settings ensure that InfluxDB always computes the query for the current time interval and for one previous time interval.
+Now, a sample of CQ 3’s frequency of batch creation and the number of queries per batch on 2015/11/24 starting at 22:09:55 (UTC) looks like this:
 
+InfluxDB generates two queries at 22:09:55:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_1h FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T22:00:00Z' AND time < '2015-11-24T23:00:00Z' GROUP BY time(1h)
 
+SELECT MEAN(value) INTO "telegraf"."default".cq_1h FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T21:00:00Z' AND time < '2015-11-24T22:00:00Z' GROUP BY time(1h)
+```
+InfluxDB generates two queries six minutes later at 22:15:55:
+```sql
+SELECT MEAN(value) INTO "telegraf"."default".cq_1h FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T22:00:00Z' AND time < '2015-11-24T23:00:00Z' GROUP BY time(1h)
+
+SELECT MEAN(value) INTO "telegraf"."default".cq_1h FROM "telegraf"."default".cpu_usage_idle WHERE cpu = 'cpu-total' AND time >= '2015-11-24T21:00:00Z' AND time < '2015-11-24T22:00:00Z' GROUP BY time(1h)
+```
+
+Because of the new settings, InfluxDB always includes in a batch one query that spans an older time interval in addition to the query that spans `now()`.
 

--- a/layouts/partials/docs/v0.9/sidebar.html
+++ b/layouts/partials/docs/v0.9/sidebar.html
@@ -50,6 +50,7 @@
 	<li><a href="/docs/v0.9/query_language/database_management.html">Database Management</a></li>
 	<li><a href="/docs/v0.9/query_language/functions.html">Functions</a></li>
 	<li><a href="/docs/v0.9/query_language/continuous_queries.html">Continuous Queries</a></li>
+	<li><a href="/docs/v0.9/query_language/continuous_queries_config.html">Configuring Continuous Queries</a></li>
 	<li><a href="/docs/v0.9/query_language/spec.html">Specification</a></li>
 	<li><a href="/docs/v0.9/query_language/query_syntax.html">Query Syntax Reference</a></li>
 	<li><a href="/docs/v0.9/query_language/math_operators.html">Mathematical Operators</a></li>


### PR DESCRIPTION
`extended_cqconfig_options.md` offers an in-depth discussion about the continuous query (CQ) configuration options and how they affect different CQs.

All feedback is welcome - the wording in this document has been a particular challenge.