### PR TITLE
Kapacitor 0.2 release blog

### DIFF
--- a/content/blog/2015/12/08/kapacitor_0.2.md
+++ b/content/blog/2015/12/08/kapacitor_0.2.md
@@ -1,0 +1,27 @@
+---
+title: Kapacitor 0.2.0 Bug Fix Release
+author: Nathaniel Cook
+date: 2015-12-08
+publishdate: 2015-12-08
+---
+
+Kapacitor version 0.2.0 has been released today.
+This release is a bug fix release since the initial release last week.
+We want to commit to making regular updates to Kapacitor, so we are going to follow a regular release cadance.
+If a feature is ready when the next release comes around it will be included, if not it will have to wait for a later release.
+Iteratively we will be able to fix bugs and push out quality features.
+Our initial plans are to cut a release every month.
+Time will tell if this is the right cadance for Kapacitor or if we should adjust.
+
+We have received great feedback from the community in the past several days since the initial release.
+We are constructing a roadmap based on that feedback for the next several months of feature development for Kapacitor.
+The next big feature to hit Kapacitor will be custom user functions.
+This will enable you to plugin in your own custom algorithms for running anomaly detection or ETL jobs, etc.
+Since integrating your custom code to another software stack can be tedious and difficult process, we are making ease of use a priority for this feature.
+We want to get it right so that it meets your needs while not being a difficult and cumbersome task.
+One of our big questions for the community is what languages would you like supported for integrating your algorithms with Kapacitor?
+Let us know on the github issue [here](https://github.com/influxdb/kapacitor/issues/72).
+Or if you have specific ideas on how you would like to see this feature work please chime in as well.
+
+That's it for now. Kapacitor's next release will be in January.
+


### PR DESCRIPTION
Simple post explaining the roadmap and release cadance of Kapacitor, plus the 0.2.0 bug fix release.